### PR TITLE
Update README to indicate heroku application name vs environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ First, you need to login with heroku cli:
 
 Then, you can use the `ec` command
 
-Create a file showing differences between 2 or more heroku environments:
+Create a file showing differences between 2 or more heroku applications:
 
-    ec diff env1 env2 env3
+    ec diff heroku-app-name1 heroku-app-name2 heroku-app-name3
 
 ## Development
 
@@ -58,7 +58,7 @@ To test this on your machine locally, after cloning the repo:
 
     git clone https://github.com/jaydorsey/env_compare.git && cd env_compare
     bundle
-    bundle exec exe/ec diff env1 env2
+    bundle exec ec diff heroku-app-name1 heroku-app-name2
 
 ## Contributing
 


### PR DESCRIPTION
Suggesting change to indicate `heroku-app-name` vs `env1` for better clarity on usage and what we are checking.

## Example

Running `bundle exec ec diff production staging` produces error messages below.
```
Fetching production environment variables
 ›   Error: You do not have access to the app production.
 ›
 ›   Error ID: forbidden
Fetching staging environment variables
 ›   Error: Couldn't find that app.
 ›
 ›   Error ID: not_found
```

Running `bundle exec ec diff sushi-production sushi-staging` solves this knowing I needed to use the actual heroku app name.