### PR TITLE
Update Colors to Accessible

### DIFF
--- a/lib/env_compare.rb
+++ b/lib/env_compare.rb
@@ -54,19 +54,19 @@ module EnvCompare
             <head>
             <style>
             table {
-              background: #121212;
-              color: #af87ff;
+              background: #000;
+              color: #da8fff;
               table-layout: fixed;
               width: 100%;
             }
 
             table, th, td {
-              border: 1px solid #424d66;
+              border: 1px solid #636366;
               border-collapse: collapse;
             }
 
             th {
-              color: #ff9700;
+              color: #ffb340;
               font-family: Arial, Helvetica, sans-serif;
               letter-spacing: 1px;
             }
@@ -77,7 +77,7 @@ module EnvCompare
             }
 
             td:first-child {
-              color: #62d8f1;
+              color: #409cff;
             }
             </style>
             </head>


### PR DESCRIPTION
Updated Colors using [Apple Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/color/). Wasn't sure on the background, so I used straight `#000` and tested each color against [WebAIM](https://webaim.org/resources/contrastchecker/) as suggested in https://github.com/jaydorsey/env_compare/pull/2.

## Before
<img width="807" alt="after1" src="https://user-images.githubusercontent.com/44587895/84461540-8e542980-ac21-11ea-84da-3aea9c282abc.png">

## After
<img width="866" alt="after2" src="https://user-images.githubusercontent.com/44587895/84461550-92804700-ac21-11ea-9cc5-362c3c8a1f71.png">
