### PR TITLE
Update Light Mode with Color Accessible + CSS Linting

### DIFF
--- a/themes/light.erb
+++ b/themes/light.erb
@@ -1,23 +1,33 @@
 <html>
   <head>
   <style>
+  :root {
+    --black: #000;
+    --blue: #0040dd;
+    --gray: #545456;
+    --white: #fff;
+  }
+
   body {
-    background: #fff;
+    background: var(--white);
     font-family: Arial, Helvetica, sans-serif;
   }
+
   table {
-    color: #000;
+    color: var(--black);
     table-layout: fixed;
     width: 100%;
   }
 
-  table, th, td {
-    border: 1px solid #636366;
+  table,
+  th,
+  td {
+    border: 1px solid var(--gray);
     border-collapse: collapse;
   }
 
   th {
-    color: #000;
+    color: var(--black);
     letter-spacing: 1px;
   }
 
@@ -27,7 +37,7 @@
   }
 
   td:first-child {
-    color: #409cff;
+    color: var(--blue);
   }
   </style>
   </head>


### PR DESCRIPTION
Update Light Mode to use Accessible Colors, tested each color against [WebAIM](https://webaim.org/resources/contrastchecker/).

## Before
<img width="860" alt="before" src="https://user-images.githubusercontent.com/44587895/84529319-1d028e00-ac96-11ea-86e8-aac91fda7d17.png">

## After
<img width="856" alt="after" src="https://user-images.githubusercontent.com/44587895/84529328-1f64e800-ac96-11ea-9fee-efd9430eda23.png">

## TODO (as separate PR's)
- Lint Dark Mode
- Fix Count (remove -1), possibly remove word `keys` since last columns are `values`.
