### PR TITLE
Lint Dark Mode

### DIFF
--- a/themes/dark.erb
+++ b/themes/dark.erb
@@ -1,23 +1,34 @@
 <html>
   <head>
   <style>
+  :root {
+    --black: #000;
+    --blue: #409cff;
+    --gray-object-only: #636366;
+    --orange: #ffb340;
+    --purple: #da8fff;
+  }
+
   body {
-    background: #000;
+    background: var(--black);
     font-family: Arial, Helvetica, sans-serif;
   }
+
   table {
-    color: #da8fff;
+    color: var(--purple);
     table-layout: fixed;
     width: 100%;
   }
 
-  table, th, td {
-    border: 1px solid #636366;
+  table,
+  th,
+  td {
+    border: 1px solid var(--gray-object-only);
     border-collapse: collapse;
   }
 
   th {
-    color: #ffb340;
+    color: var(--orange);
     letter-spacing: 1px;
   }
 
@@ -27,7 +38,7 @@
   }
 
   td:first-child {
-    color: #409cff;
+    color: var(--blue);
   }
   </style>
   </head>


### PR DESCRIPTION
Named `gray-object-only` to indicate the color only passes [WebAIM](https://webaim.org/resources/contrastchecker/) for `Graphical Objects and User Interface Components`. If we need to use a `gray` for font coloring, we need to use a different color.

Finding a `gray` that passed all for every scenarios made the borders a bit too bright and distracting for the theme. Examples shown below. Happy to change to either one based on your thoughts.

## Gray UI Only
<img width="875" alt="ui-only" src="https://user-images.githubusercontent.com/44587895/84532939-06f7cc00-ac9c-11ea-8ee1-d25a9ade789c.png">

## Gray for Everything
- Found by using lightest `gray`  on [Apple Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/color/) for `dark accessible` and dragging slider on `WebAIM` (`#8e8e93` to `#97979B`) .
<img width="876" alt="all-97979B" src="https://user-images.githubusercontent.com/44587895/84533286-aae17780-ac9c-11ea-9e40-8fcbf0e087c3.png">

