### PR TITLE
Fix Header Counts and Wording

### DIFF
--- a/themes/dark.erb
+++ b/themes/dark.erb
@@ -33,25 +33,30 @@
   </head>
   <body>
     <table>
-      <tr>
-      <% headers.each_with_index do |header, idx| %>
-        <th>
-          <%= header %>&nbsp;
-          (<%= data.map { |col| col[idx] }.compact.size - 1 %> keys)
-        </th>
-      <% end %>
-      </tr>
-      <% data.each do |row| %>
+      <thead>
         <tr>
-          <% row.each do |cell| %>
-            <td>
-              <% unless cell.nil? %>
-                <code><%= cell %></code>
-              <% end %>
-            </td>
+          <% headers.each_with_index do |header, idx| %>
+            <th>
+              <%= header %>&nbsp;
+              (<%= data.map { |col| col[idx] }.compact.size %>)
+            </th>
           <% end %>
         </tr>
-      <% end %>
+      </thead>
+
+      <tbody>
+        <% data.each do |row| %>
+          <tr>
+            <% row.each do |cell| %>
+              <td>
+                <% unless cell.nil? %>
+                  <code><%= cell %></code>
+                <% end %>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
     </table>
   </body>
 </html>

--- a/themes/light.erb
+++ b/themes/light.erb
@@ -43,25 +43,30 @@
   </head>
   <body>
     <table>
-      <tr>
-      <% headers.each_with_index do |header, idx| %>
-        <th>
-          <%= header %>&nbsp;
-          (<%= data.map { |col| col[idx] }.compact.size - 1 %> keys)
-        </th>
-      <% end %>
-      </tr>
-      <% data.each do |row| %>
+      <thead>
         <tr>
-          <% row.each do |cell| %>
-            <td>
-              <% unless cell.nil? %>
-                <code><%= cell %></code>
-              <% end %>
-            </td>
-          <% end %>
+        <% headers.each_with_index do |header, idx| %>
+          <th>
+            <%= header %>&nbsp;
+            (<%= data.map { |col| col[idx] }.compact.size %>)
+          </th>
+        <% end %>
         </tr>
-      <% end %>
+      </thead>
+
+      <tbody>
+        <% data.each do |row| %>
+          <tr>
+            <% row.each do |cell| %>
+              <td>
+                <% unless cell.nil? %>
+                  <code><%= cell %></code>
+                <% end %>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
     </table>
   </body>
 </html>


### PR DESCRIPTION
- Fixed Key and Value Counts for Header.
- Removed word `keys` after count since `key` is for first column only and the rest are `values`.
- Added `thead` & `tbody` tags and adjusted indentation. Although additional tags are not required, I find it to be a good structure and allows for more variation in styling in a more semantic fashion.

## Before
<img width="946" alt="before" src="https://user-images.githubusercontent.com/44587895/84535975-bedba800-aca1-11ea-8493-b85515841082.png">

## After
<img width="946" alt="after" src="https://user-images.githubusercontent.com/44587895/84535982-c26f2f00-aca1-11ea-8660-cc7a8d7e5b52.png">
