### PR TITLE
Add Missing RuboCops + light linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,14 +16,56 @@ require:
 Layout/LineLength:
   Max: 120
 
-Style/Documentation:
-  Enabled: false
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
 
 Metrics/MethodLength:
   Max: 15
 
-Layout/DotPosition:
-  EnforcedStyle: trailing
 
-Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented
+Style/Documentation:
+  Enabled: false
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
+  Enabled: true
+
+Style/SlicingWithRange:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in env_compare.gemspec
 gemspec
 
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"
+gem 'rake', '~> 12.0'
+gem 'rspec', '~> 3.0'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "env_compare"
+require 'bundler/setup'
+require 'env_compare'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
 # (If you use this, don't forget to add pry to your Gemfile!)
-require "pry"
+require 'pry'
 Pry.start

--- a/exe/ec
+++ b/exe/ec
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 
-require "env_compare"
+require 'env_compare'
 
 EnvCompare::CLI.start(ARGV)

--- a/spec/env_compare_spec.rb
+++ b/spec/env_compare_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 RSpec.describe EnvCompare do
-  it "has a version number" do
+  it 'has a version number' do
     expect(EnvCompare::VERSION).not_to be nil
   end
 
-  it "does something useful" do
+  it 'does something useful' do
     expect(false).to eq(true)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,11 @@
-require "bundler/setup"
-require "env_compare"
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'env_compare'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!


### PR DESCRIPTION
- Added missing cops (editor yelling at me), enabled all missing ones as `true` unless you have strong options on anything specific.
- Added light linting - can happily remove if this should be addressed on a per file touched basis.
- Re-organized and put in alpha order by Group.