### PR TITLE
Start CLI Spec

### DIFF
--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe EnvCompare::CLI do
+  describe '#version' do
+    it 'shows version' do
+      expect(STDOUT).to receive(:puts).with(EnvCompare::VERSION)
+
+      described_class.start(['version'])
+    end
+  end
+end

--- a/spec/env_compare_spec.rb
+++ b/spec/env_compare_spec.rb
@@ -4,8 +4,4 @@ RSpec.describe EnvCompare do
   it 'has a version number' do
     expect(EnvCompare::VERSION).not_to be nil
   end
-
-  it 'does something useful' do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
- Remove generated default failing spec.
- Start CLI Spec.
  - Not much to it yet. Need to work through stubbing `list` method and testing each scenario + options.

## Other Thoughts
- We may want to add `rubocop-rspec` as well before jamming through tests.
- Possibility rename `lib/env_compare.rb` to `lib/cli.rb` or something as this initially confused me when adding the spec for `EnvCompare::CLI`