### PR TITLE
Switch to use Heroku Platform API gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     env_compare (0.1.1)
       launchy
+      platform-api
       thor
 
 GEM
@@ -13,18 +14,32 @@ GEM
     ast (2.4.1)
     coderay (1.1.3)
     diff-lcs (1.3)
+    erubis (2.7.0)
+    excon (0.75.0)
+    heroics (0.1.1)
+      erubis (~> 2.0)
+      excon
+      moneta
+      multi_json (>= 1.9.2)
     launchy (2.5.0)
       addressable (~> 2.7)
     method_source (1.0.0)
+    moneta (1.0.0)
+    multi_json (1.14.1)
     parallel (1.19.1)
     parser (2.7.1.3)
       ast (~> 2.4.0)
+    platform-api (3.0.0)
+      heroics (~> 0.1.1)
+      moneta (~> 1.0.0)
+      rate_throttle_client (~> 0.1.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.5)
     rainbow (3.0.0)
     rake (12.3.3)
+    rate_throttle_client (0.1.2)
     regexp_parser (1.7.1)
     rexml (3.2.4)
     rspec (3.9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    env_compare (0.1.1)
+    env_compare (0.1.2)
       launchy
       platform-api
       thor

--- a/README.md
+++ b/README.md
@@ -11,31 +11,36 @@ production environment variables
 This gem helps pull down the environment variables and give you
 a little interface to view & compare them with (via a UI)
 
-No server; it's all done via a CLI. It's really just a wrapper around
-some commands around the [heroku cli](https://devcenter.heroku.com/articles/heroku-cli) that does some formatting and
-munging of the output so you don't have to copy it all to Excel
-
-This gem wraps the heroku CLI tool to generates a small temporary
-HTML file & opens it using [launchy](https://github.com/copiousfreetime/launchy)
+The heavy lifting is done via the [heroku platform-api gem](https://github.com/heroku/platform-api)
+to retrieve environment variables, format them in an HTML page, and
+generate a small HTML file and open it with [launchy](https://github.com/copiousfreetime/launchy)
 
 It automates a few things:
 - Hides environment variables that match across all environments
 - Puts them in alpha order
 
 It's primarily intended to compare pre-production ENV variables
+across similar/identical environments
 
 ## Installation
 
 ### Prerequisites
-- Install Heroku CLI
-  ```bash
-  brew tap heroku/brew && brew install heroku
-  ```
 
-- Login with Heroku CLI
-  ```bash
-  heroku login
-  ```
+```bash
+# Install Heroku CLI
+brew tap heroku/brew && brew install heroku
+# Login with Heroku CLI
+heroku login
+
+# Install the heroku oauth plugin to generate an OAuth token
+heroku plugins:install heroku-cli-oauth
+
+# Create a token to access your applications
+heroku authorizations:create -d "Platform API token for environment variables"
+
+# Set the Token from above to an environment variable
+export OAUTH_TOKEN=<token>
+```
 
 ### Install gem
 ```bash
@@ -43,7 +48,6 @@ gem install env_compare
 ```
 
 After installation you should have access to the `ec` executable wrapper.
-
 
 ## Usage
 Use `ec` command to start comparing 2 or more heroku application environment variables.
@@ -62,7 +66,7 @@ ec diff --all heroku-app-name1 heroku-app-name2 heroku-app-name3
 ```
 
 ### Themes
-- `--theme dark` **default*
+- `--theme dark` **default**
 - `--theme light`
 
 For Example:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ across similar/identical environments
 ```bash
 # Install Heroku CLI
 brew tap heroku/brew && brew install heroku
+
 # Login with Heroku CLI
 heroku login
 
@@ -40,6 +41,14 @@ heroku authorizations:create -d "Platform API token for environment variables"
 
 # Set the Token from above to an environment variable
 export OAUTH_TOKEN=<token>
+```
+
+If you want to add the environment variable to your shell permanently, you can
+run a variation of the command below:
+
+```bash
+# Add permanently to `.bash_profile`
+echo 'export OAUTH_TOKEN=<token>' >>~/.bash_profile
 ```
 
 ### Install gem

--- a/env_compare.gemspec
+++ b/env_compare.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'launchy'
   spec.add_dependency 'thor'
+  spec.add_dependency 'platform-api'
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rspec'

--- a/lib/env_compare/version.rb
+++ b/lib/env_compare/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EnvCompare
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end


### PR DESCRIPTION
This is an MVP; we should also look at adding an argument/flag to allow
the OAUTH_TOKEN to be passed in via CLI if you don't want to set it via
the ENV (and in case of conflicts)

I pulled OAUTH_TOKEN from the platform api gem docs; it said it will
automatically read that token itself (maybe I should test it locally
without and see if it finds it even when I don't specify it?)

Closes #10 