### PR TITLE
Update Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # CHANGELOG
 
-## Version 0.1.1
+## [Unreleased]
+## [0.1.3.pre.beta]
+- Added `force` and `no-force` options for updating environment variables.
 
-Improve description example on `diff` option
+## [Released]
+### [0.1.3.pre.alpha] - 2020-07-29
+- Added Heroku Oauth.
+- Added ability to update/remove environment variables.
 
-## Version 0.1.0
+### [0.1.1] - 2020-06-12
+- Improve description example on `diff` option.
 
-Initial release. Includes a `diff` option & 2 themes
+### [0.1.0] - 2020-06-12
+- Initial release. Includes a `diff` option & 2 themes.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Use `ec` command to start comparing 2 or more heroku application environment var
 
 When only one application name is specified, output is shown in cli. Otherwise, your default browser is launched.
 
-## Compariing environment variables
+## Comparing environment variables
 
 ### Show **differences** **default*
 ```bash


### PR DESCRIPTION
- Updated `CHANGELOG` to follow https://keepachangelog.com/en/1.0.0/ . I know we may use a different tool in the future, so the formatting may change. I thought it might be good to use some sort of format in the interim.
  - Captured Releases and Dates from https://rubygems.org/gems/env_compare