### PR TITLE
Add Reload to console

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -9,4 +9,18 @@ require 'env_compare'
 
 # (If you use this, don't forget to add pry to your Gemfile!)
 require 'pry'
+
+def reload!
+  puts 'Reloading ...'
+
+  root_dir = File.expand_path('..', __dir__)
+  reload_dirs = %w[lib]
+
+  reload_dirs.each do |dir|
+    Dir.glob("#{root_dir}/#{dir}/**/*.rb").each { |file| load(file) }
+  end
+
+  true
+end
+
 Pry.start


### PR DESCRIPTION
I found this super useful after reading https://cobwwweb.com/add-reload-method-to-ruby-console

To use:
```
$ chmod +x bin/console
$ bundle exec bin/console
> EnvCompare::VERSION
=> "0.1.3-beta"

## make change to `VERSION` in `lib/env_compare/version.rb`
> reload!
Reloading ...

> EnvCompare::VERSION
=> "0.1.3-betacac"
```

- The output of each file is a bit annoying - can probably find a way to suppress that.
- Probably don't need the `reload_dirs.each` and can do `Dir.glob("#{root_dir}/lib/**/*.rb").each { |file| load(file) }` unless we ever go outside the `lib` directory.