### PR TITLE
Cleanup Reload Method

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -11,16 +11,8 @@ require 'env_compare'
 require 'pry'
 
 def reload!
-  puts 'Reloading ...'
-
-  root_dir = File.expand_path('..', __dir__)
-  reload_dirs = %w[lib]
-
-  reload_dirs.each do |dir|
-    Dir.glob("#{root_dir}/#{dir}/**/*.rb").each { |file| load(file) }
-  end
-
-  true
+  puts 'Reloading...'
+  exec 'bin/console'
 end
 
 Pry.start


### PR DESCRIPTION
I think this solves it much cleaner using [Kernel#exec](https://ruby-doc.org/core-2.7.1/Kernel.html#method-i-exec) by replacing current process. Since `require 'env_compare'` is already stated, we shouldn't have to iterate through files again in the method. Bonus - none of that output noise.

Implementation captured from [racksh reload!](https://github.com/sickill/racksh/blob/a5fbc6137bb110bf1e5644c3c5e9e04a6711f4e2/lib/racksh/init.rb#L9-L13)