### PR TITLE
Add license to gemspec

### DIFF
--- a/env_compare.gemspec
+++ b/env_compare.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |spec|
   spec.version = EnvCompare::VERSION
   spec.authors = ['Jay Dorsey']
   spec.email = ['jaydorsey@fastmail.com']
+  spec.license = 'MIT'
 
   spec.summary = 'Compare ENV variables across Heroku environments'
   spec.description = 'Compare ENV variables across Heroku environments'


### PR DESCRIPTION
Add license to Gemspec per [ruby specification](https://guides.rubygems.org/specification-reference/#license=). This makes it clear for anyone using this code of the license type. In addition, automated tools like [`license_finder`](https://github.com/pivotal/LicenseFinder) can now detect the license type for this gem. This will now show the license type on the [env_compare RubyGems page](https://rubygems.org/gems/env_compare/versions/0.1.4) as well.
- Should have added this in https://github.com/jaydorsey/env_compare/pull/19 ...my bad!